### PR TITLE
Changes static repo URL to discovery via github

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -86,6 +86,20 @@ catalog:
     pullRequestBranchName: backstage-integration
   rules:
     - allow: [Component, System, API, Resource, Location]
+  providers:
+    github:
+      # the provider ID can be any camelCase string
+      providerId:
+        organization: 'chillerm' # string
+        catalogPath: '/catalog-info.yaml' # string
+        filters:
+          branch: 'master' # string
+          repository: 'backstage.*' # Regex
+        schedule: # same options as in SchedulerServiceTaskScheduleDefinition
+          # supports cron, ISO duration, "human duration" as used in code
+          frequency: { minutes: 30 }
+          # supports ISO duration, "human duration" as used in code
+          timeout: { minutes: 3 }
   locations:
     # Local example data, file locations are relative to the backend process, typically `packages/backend`
     - type: file
@@ -103,8 +117,6 @@ catalog:
       rules:
         - allow: [User, Group]
 
-    - type: url
-      target: https://github.com/chillerm/backstage-example-node-app/blob/master/catalog-info.yaml
 
     ## Uncomment these lines to add more example data
     # - type: url

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,6 +24,7 @@
     "@backstage/plugin-auth-backend-module-guest-provider": "^0.2.6",
     "@backstage/plugin-auth-node": "^0.6.1",
     "@backstage/plugin-catalog-backend": "^1.32.0",
+    "@backstage/plugin-catalog-backend-module-github": "^0.7.11",
     "@backstage/plugin-catalog-backend-module-logs": "^0.1.8",
     "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "^0.2.6",
     "@backstage/plugin-kubernetes-backend": "^0.19.4",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -28,6 +28,7 @@ backend.add(import('@backstage/plugin-catalog-backend'));
 backend.add(
   import('@backstage/plugin-catalog-backend-module-scaffolder-entity-model'),
 );
+backend.add(import('@backstage/plugin-catalog-backend-module-github'));
 
 // See https://backstage.io/docs/features/software-catalog/configuration#subscribing-to-catalog-errors
 backend.add(import('@backstage/plugin-catalog-backend-module-logs'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -4011,6 +4011,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-catalog-backend-module-github@npm:^0.7.11":
+  version: 0.7.11
+  resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.7.11"
+  dependencies:
+    "@backstage/backend-common": "npm:^0.25.0"
+    "@backstage/backend-plugin-api": "npm:^1.2.1"
+    "@backstage/catalog-client": "npm:^1.9.1"
+    "@backstage/catalog-model": "npm:^1.7.3"
+    "@backstage/config": "npm:^1.3.2"
+    "@backstage/integration": "npm:^1.16.2"
+    "@backstage/plugin-catalog-backend": "npm:^1.32.0"
+    "@backstage/plugin-catalog-common": "npm:^1.1.3"
+    "@backstage/plugin-catalog-node": "npm:^1.16.1"
+    "@backstage/plugin-events-node": "npm:^0.4.9"
+    "@octokit/core": "npm:^5.2.0"
+    "@octokit/graphql": "npm:^7.0.2"
+    "@octokit/plugin-throttling": "npm:^8.1.3"
+    "@octokit/rest": "npm:^19.0.3"
+    git-url-parse: "npm:^15.0.0"
+    lodash: "npm:^4.17.21"
+    minimatch: "npm:^9.0.0"
+    uuid: "npm:^11.0.0"
+  checksum: 10c0/1454d05a94ea161322a203489a103a29f884d7877e9bd24d53d7ecd3fb5fcbe6b6932f4ff8515dae5573d64e5b420c1bd87fd80b892cdbec8a87c6796d5fa93a
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-catalog-backend-module-logs@npm:^0.1.8":
   version: 0.1.8
   resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.8"
@@ -8398,7 +8424,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/core@npm:^5.0.0":
+"@octokit/core@npm:^5.0.0, @octokit/core@npm:^5.2.0":
   version: 5.2.1
   resolution: "@octokit/core@npm:5.2.1"
   dependencies:
@@ -8455,7 +8481,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/graphql@npm:^7.1.0":
+"@octokit/graphql@npm:^7.0.2, @octokit/graphql@npm:^7.1.0":
   version: 7.1.1
   resolution: "@octokit/graphql@npm:7.1.1"
   dependencies:
@@ -8654,7 +8680,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/plugin-throttling@npm:^8.0.0":
+"@octokit/plugin-throttling@npm:^8.0.0, @octokit/plugin-throttling@npm:^8.1.3":
   version: 8.2.0
   resolution: "@octokit/plugin-throttling@npm:8.2.0"
   dependencies:
@@ -14511,6 +14537,7 @@ __metadata:
     "@backstage/plugin-auth-backend-module-guest-provider": "npm:^0.2.6"
     "@backstage/plugin-auth-node": "npm:^0.6.1"
     "@backstage/plugin-catalog-backend": "npm:^1.32.0"
+    "@backstage/plugin-catalog-backend-module-github": "npm:^0.7.11"
     "@backstage/plugin-catalog-backend-module-logs": "npm:^0.1.8"
     "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": "npm:^0.2.6"
     "@backstage/plugin-kubernetes-backend": "npm:^0.19.4"


### PR DESCRIPTION
This pull request includes several changes to the `catalog` configuration and backend setup in the Backstage application. The main changes involve adding a GitHub provider to the catalog configuration and updating the backend dependencies to support this new provider.

### Catalog Configuration Updates:
* [`app-config.yaml`](diffhunk://#diff-ec52f22d476ccc33271d11c4f08a68369614378aa0cb9aa5aba2f08943cd68dfR89-R102): Added a new GitHub provider configuration under the `catalog` section to integrate with the GitHub repository. This includes setting the provider ID, organization, catalog path, filters, and schedule.
* [`app-config.yaml`](diffhunk://#diff-ec52f22d476ccc33271d11c4f08a68369614378aa0cb9aa5aba2f08943cd68dfL106-L107): Removed an example URL-based catalog location.

### Backend Setup Updates:
* [`packages/backend/package.json`](diffhunk://#diff-e095a6dd10bb40447d8290e79f70c15334e874e757e25a569b9d3449ed4fe27dR27): Added the `@backstage/plugin-catalog-backend-module-github` dependency to support the new GitHub provider.
* [`packages/backend/src/index.ts`](diffhunk://#diff-2ef3cf9bf12d21de5f65f0c473654ec6d62ac76a214fbf53a4afa2d3a92e7bf3R31): Included the `@backstage/plugin-catalog-backend-module-github` in the backend setup to enable the GitHub provider functionality.